### PR TITLE
modify borrowck rules, particularly around mutable borrows

### DIFF
--- a/nll/src/borrowck.rs
+++ b/nll/src/borrowck.rs
@@ -43,21 +43,21 @@ impl<'cx> BorrowCheck<'cx> {
         log!("check_action({:?}) at {:?}", action, self.point);
         match action.kind {
             repr::ActionKind::Init(ref a, ref bs) => {
-                self.check_instantaneous_write(a)?;
+                self.check_shallow_write(a)?;
                 for b in bs {
                     self.check_read(b)?;
                 }
             }
             repr::ActionKind::Assign(ref a, ref b) => {
-                self.check_instantaneous_write(a)?;
+                self.check_shallow_write(a)?;
                 self.check_read(b)?;
             }
             repr::ActionKind::Borrow(ref a, _, repr::BorrowKind::Shared, ref b) => {
-                self.check_instantaneous_write(a)?;
+                self.check_shallow_write(a)?;
                 self.check_read(b)?;
             }
             repr::ActionKind::Borrow(ref a, _, repr::BorrowKind::Mut, ref b) => {
-                self.check_instantaneous_write(a)?;
+                self.check_shallow_write(a)?;
                 self.check_mut_borrow(b)?;
             }
             repr::ActionKind::Constraint(_) => {}
@@ -85,7 +85,7 @@ impl<'cx> BorrowCheck<'cx> {
 
     /// `x = ...` overwrites `x` (without reading it) and prevents any
     /// further reads from that path.
-    fn check_instantaneous_write(&self, path: &repr::Path) -> Result<(), Box<Error>> {
+    fn check_shallow_write(&self, path: &repr::Path) -> Result<(), Box<Error>> {
         self.check_borrows(Depth::Shallow, Mode::Write, path)
     }
 

--- a/test/issue-38-2.nll
+++ b/test/issue-38-2.nll
@@ -1,0 +1,31 @@
+// // set the scene
+// x = Some(0);
+// y = &mut x;
+// assert(Discr(*y) is Some);
+// z = &(*y as Some).0; // (*)
+// 
+// // ... and then
+// t = &mut y;
+// **t = None;
+// // oops
+// use(z);
+
+struct Map { value: Value }
+struct Value { }
+
+let x: Map;
+let y: &'_ mut Map;
+let z: &'_ Value;
+let t: &'_ &'_ mut Map;
+
+block START {
+  x = use();
+  y = &'_ mut x;
+  z = &'_ (*y).value;
+
+  t = &'_ y; // A `read` of y
+  use(t);
+  y = use(); // A `write` to `y`
+  // the borrow `(*)` is now "orphaned", so using it is ok.
+  use(z);
+}

--- a/test/issue-38.nll
+++ b/test/issue-38.nll
@@ -1,0 +1,29 @@
+// // set the scene
+// x = Some(0);
+// y = &mut x;
+// assert(Discr(*y) is Some);
+// z = &(*y as Some).0; // (*)
+// 
+// // ... and then
+// t = &mut y;
+// **t = None;
+// // oops
+// use(z);
+
+struct Map { value: Value }
+struct Value { }
+
+let x: Map;
+let y: &'_ mut Map;
+let z: &'_ Value;
+let t: &'_ mut &'_ mut Map;
+
+block START {
+  x = use();
+  y = &'_ mut x;
+  z = &'_ (*y).value;
+
+  t = &'_ mut y; //! ERROR
+  **t = use();
+  use(z);
+}


### PR DESCRIPTION
This also refactors the "check_read" etc routines into one helper with two orthogonal axes (shallow/deep, read/write).

cc nikomatsakis/nll-rfc#38 @arielb1 