### PR TITLE
Include outlives endpoints in inference and fix typo in test assertion

### DIFF
--- a/test/vec-push-ref.nll
+++ b/test/vec-push-ref.nll
@@ -37,7 +37,7 @@ assert EXIT/0 in 'p;
 assert v not live at START;
 assert v live at B;
 assert v live at C;
-assert v not live at START;
+assert v live at EXIT;
 
 assert p not live at START;
 assert p live at B;


### PR DESCRIPTION
From our conversations on gitter, I believe this is where you wanted to go next (sorry if I jumped ahead and we're not ready for this yet). I also found what I think was a copy/paste error in one of the test validations. The origin validation was checked for a second time, and there was none for the exit case on v.