### PR TITLE
Fix typo in test

### DIFF
--- a/test/vec-push-ref.nll
+++ b/test/vec-push-ref.nll
@@ -37,7 +37,7 @@ assert EXIT/0 in 'p;
 assert v not live at START;
 assert v live at B;
 assert v live at C;
-assert v not live at START;
+assert v live at EXIT;
 
 assert p not live at START;
 assert p live at B;


### PR DESCRIPTION
I believe the existing assertion is a duplicate of the one on line 37. I think this new assertion would be helpful. Let me know if you'd rather just delete the line.